### PR TITLE
Updated template resolver

### DIFF
--- a/Controllers/Test02.php
+++ b/Controllers/Test02.php
@@ -2,22 +2,21 @@
 
 namespace App\Controllers;
 
-use App\Renderer\TemplateRenderer;
+use Latte\Engine;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 
 class Test02 extends MyController
 {
-    public function __construct(private TemplateRenderer $renderer)
+    public function __construct(private Engine $engine)
     {
     }
 
     public function index(Request $request, Response $response): Response
     {
         $items = ['one', 'two', 'three', 'Héllo', 'a@\'t"esté'];
-
-        return $this->renderer->template($response, 'Test02.latte', ['items' => $items, 'title' => 'From Test02']);
-
-        
+        $string = $this->engine->renderToString('Test02.latte', ['items' => $items, 'title' => 'From Test02']);
+        $response->getBody()->write($string);
+        return $response;
     }
 }

--- a/Controllers/Test03.php
+++ b/Controllers/Test03.php
@@ -2,13 +2,13 @@
 
 namespace App\Controllers;
 
-use App\Renderer\TemplateRenderer;
+use Latte\Engine;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 
 class Test03 extends MyController
 {
-    public function __construct(private TemplateRenderer $renderer)
+    public function __construct(private Engine $engine)
     {
     }
 
@@ -18,8 +18,8 @@ class Test03 extends MyController
 
         // Missing $items variable
 
-        return $this->renderer->template($response, 'Test03.latte', ['title' => 'From Test02']);
-
-        
+        $string = $this->engine->renderToString('Test03.latte', ['title' => 'From Test03']);
+        $response->getBody()->write($string);
+        return $response;
     }
 }

--- a/Renderer/TemplateResolver.php
+++ b/Renderer/TemplateResolver.php
@@ -1,19 +1,104 @@
 <?php
 namespace App\Renderer;
 
-use Efabrica\PHPStanLatte\LatteContext\Resolver\LatteContextResolverInterface;
-use Efabrica\PHPStanLatte\LatteTemplateResolver\AbstractClassMethodTemplateResolver;
+use Efabrica\PHPStanLatte\Collector\CollectedData\CollectedResolvedNode;
+use Efabrica\PHPStanLatte\LatteContext\LatteContext;
+use Efabrica\PHPStanLatte\LatteContext\LatteContextHelper;
+use Efabrica\PHPStanLatte\LatteTemplateResolver\LatteTemplateResolverResult;
+use Efabrica\PHPStanLatte\LatteTemplateResolver\NodeLatteTemplateResolverInterface;
+use Efabrica\PHPStanLatte\Resolver\NameResolver\NameResolver;
+use Efabrica\PHPStanLatte\Resolver\ValueResolver\ValueResolver;
+use Efabrica\PHPStanLatte\Template\Template;
+use Efabrica\PHPStanLatte\Template\TemplateContext;
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Type\ObjectType;
 
-final class TemplateResolver extends AbstractClassMethodTemplateResolver
+final class TemplateResolver implements NodeLatteTemplateResolverInterface
 {
-    public function getSupportedClasses(): array
-    {
-        return ['App\Controllers\MyController'];
+    private const PATHS = 'paths';
+
+    private const VARIABLES = 'variables';
+
+    public function __construct(
+        private NameResolver $nameResolver,
+        private ValueResolver $valueResolver
+    ) {
     }
 
-    protected function getClassMethodPattern(): string
+    public function collect(Node $node, Scope $scope): array
     {
-        return '/^index$/';
+        if (!$node instanceof MethodCall) {
+            return [];
+        }
+
+        if ($this->nameResolver->resolve($node) !== 'renderToString') {
+            return [];
+        }
+
+        $callerType = $scope->getType($node->var);
+        if (!$callerType instanceof ObjectType) {
+            return [];
+        }
+        if (!$callerType->isInstanceOf('Latte\Engine')->yes()) {
+            return [];
+        }
+
+        return [
+            new CollectedResolvedNode(self::class, $scope->getFile(), [
+                self::PATHS => $this->getPaths($node, $scope),
+                self::VARIABLES => $this->getVariables($node, $scope),
+            ]),
+        ];
+    }
+
+    public function resolve(CollectedResolvedNode $resolvedNode, LatteContext $latteContext): LatteTemplateResolverResult
+    {
+        $params = $resolvedNode->getParams();
+        $paths = $params[self::PATHS] ?? [];
+        $variables = $params[self::VARIABLES] ?? [];
+
+        $templates = [];
+        foreach ($paths as $path) {
+            $templateContext = new TemplateContext($variables);
+            $templates[] = new Template($path, null, null, $templateContext);
+        }
+
+        return new LatteTemplateResolverResult($templates);
+    }
+
+    private function getPaths(MethodCall $methodCall, Scope $scope): array
+    {
+        $firstArg = $methodCall->getArgs()[0] ?? null;
+        if ($firstArg === null) {
+            return [];
+        }
+
+        $paths = $this->valueResolver->resolveStrings($firstArg->value, $scope);
+        if ($paths === null) {
+            return [];
+        }
+
+        $fullPaths = [];
+        foreach ($paths as $path) {
+            $fullPaths[] = __DIR__ . '/../templates/' . $path;
+        }
+        return $fullPaths;
+    }
+
+    private function getVariables(MethodCall $methodCall, Scope $scope): array
+    {
+        $secondArg = $methodCall->getArgs()[1] ?? null;
+        if ($secondArg === null) {
+            return [];
+        }
+
+        $variables = [];
+        foreach (LatteContextHelper::variablesFromType($scope->getType($secondArg->value)) as $variable) {
+            $variables[$variable->getName()] = $variable;
+        }
+        return $variables;
     }
 }
 

--- a/Renderer/TemplateResolver.php
+++ b/Renderer/TemplateResolver.php
@@ -17,6 +17,10 @@ use PHPStan\Type\ObjectType;
 
 final class TemplateResolver implements NodeLatteTemplateResolverInterface
 {
+    private const ACTUAL_CLASS = 'actual_class';
+
+    private const ACTUAL_METHOD = 'actual_method';
+
     private const PATHS = 'paths';
 
     private const VARIABLES = 'variables';
@@ -47,6 +51,8 @@ final class TemplateResolver implements NodeLatteTemplateResolverInterface
 
         return [
             new CollectedResolvedNode(self::class, $scope->getFile(), [
+                self::ACTUAL_CLASS => $scope->getClassReflection()->getName(),
+                self::ACTUAL_METHOD => $scope->getFunctionName(),
                 self::PATHS => $this->getPaths($node, $scope),
                 self::VARIABLES => $this->getVariables($node, $scope),
             ]),
@@ -62,7 +68,7 @@ final class TemplateResolver implements NodeLatteTemplateResolverInterface
         $templates = [];
         foreach ($paths as $path) {
             $templateContext = new TemplateContext($variables);
-            $templates[] = new Template($path, null, null, $templateContext);
+            $templates[] = new Template($path, $params[self::ACTUAL_CLASS], $params[self::ACTUAL_METHOD], $templateContext);
         }
 
         return new LatteTemplateResolverResult($templates);

--- a/Renderer/VariableCollector.php
+++ b/Renderer/VariableCollector.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Renderer;
+
+use Efabrica\PHPStanLatte\LatteContext\CollectedData\CollectedVariable;
+use Efabrica\PHPStanLatte\LatteContext\Collector\AbstractLatteContextSubCollector;
+use Efabrica\PHPStanLatte\LatteContext\Collector\VariableCollector\VariableCollectorInterface;
+use Efabrica\PHPStanLatte\LatteContext\LatteContextHelper;
+use Efabrica\PHPStanLatte\Resolver\NameResolver\NameResolver;
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Type\ObjectType;
+
+final class VariableCollector extends AbstractLatteContextSubCollector implements VariableCollectorInterface
+{
+    public function __construct(
+        private NameResolver $nameResolver
+    ) {
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    /**
+     * @param MethodCall $node
+     */
+    public function collect(Node $node, Scope $scope): ?array
+    {
+        if ($this->nameResolver->resolve($node) !== 'renderToString') {
+            return [];
+        }
+
+        $callerType = $scope->getType($node->var);
+        if (!$callerType instanceof ObjectType) {
+            return [];
+        }
+        if (!$callerType->isInstanceOf('Latte\Engine')->yes()) {
+            return [];
+        }
+
+        $secondArg = $node->getArgs()[1] ?? null;
+        if ($secondArg === null) {
+            return [];
+        }
+
+        $variables = [];
+        foreach (LatteContextHelper::variablesFromType($scope->getType($secondArg->value)) as $variable) {
+            $variables[] = CollectedVariable::build($node, $scope, $variable->getName(), $variable->getType());
+        }
+        return $variables;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,6 @@
     },
     "require-dev": {
         "phpstan/phpstan": "^1.10",
-        "efabrica/phpstan-latte": "^0.11.0"
+        "efabrica/phpstan-latte": "dev-main as 0.11.1"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "210852ba777220f0a14f533614c8eaf6",
+    "content-hash": "de95a508fe3ab4905e2d9c2c89b1b474",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -1037,16 +1037,16 @@
     "packages-dev": [
         {
             "name": "efabrica/phpstan-latte",
-            "version": "0.11.0",
+            "version": "dev-main",
             "source": {
                 "type": "git",
                 "url": "https://github.com/efabrica-team/phpstan-latte.git",
-                "reference": "ebad37eb6ad3217daca944e4c3bcca8c2c72408d"
+                "reference": "f0264397d5fd0c2afad9eff7163cf48ae3366ea0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/efabrica-team/phpstan-latte/zipball/ebad37eb6ad3217daca944e4c3bcca8c2c72408d",
-                "reference": "ebad37eb6ad3217daca944e4c3bcca8c2c72408d",
+                "url": "https://api.github.com/repos/efabrica-team/phpstan-latte/zipball/f0264397d5fd0c2afad9eff7163cf48ae3366ea0",
+                "reference": "f0264397d5fd0c2afad9eff7163cf48ae3366ea0",
                 "shasum": ""
             },
             "require": {
@@ -1067,6 +1067,7 @@
                 "phpunit/phpunit": "^9.5",
                 "spaze/phpstan-disallowed-calls": "^2.11"
             },
+            "default-branch": true,
             "type": "library",
             "extra": {
                 "phpstan": {
@@ -1089,9 +1090,9 @@
             ],
             "support": {
                 "issues": "https://github.com/efabrica-team/phpstan-latte/issues",
-                "source": "https://github.com/efabrica-team/phpstan-latte/tree/0.11.0"
+                "source": "https://github.com/efabrica-team/phpstan-latte/tree/main"
             },
-            "time": "2023-05-02T08:50:55+00:00"
+            "time": "2023-05-05T08:43:39+00:00"
         },
         {
             "name": "nette/finder",
@@ -1358,9 +1359,18 @@
             "time": "2023-04-12T14:11:53+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "package": "efabrica/phpstan-latte",
+            "version": "dev-main",
+            "alias": "0.11.1",
+            "alias_normalized": "0.11.1.0"
+        }
+    ],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "efabrica/phpstan-latte": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,14 +4,13 @@ parameters:
 		- ./Controllers
 		- ./templates
 		- ./public
-		- ./compiledTemplates
 	latte:
 		reportUnanalysedTemplates: true
 		resolveAllPossiblePaths: true
+		tmpDir: %currentWorkingDirectory%/compiledTemplates/phpstan-latte
 
 services:
-  - App\Renderer\TemplateResolver
-
+	- App\Renderer\TemplateResolver
 
 includes:
 	- ./vendor/efabrica/phpstan-latte/rules.neon

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,6 +11,7 @@ parameters:
 
 services:
 	- App\Renderer\TemplateResolver
+	- App\Renderer\VariableCollector
 
 includes:
 	- ./vendor/efabrica/phpstan-latte/rules.neon


### PR DESCRIPTION
I've implemented some working solution for you. 

It is able to solve using:
```
$items = ['one', 'two', 'three', 'Héllo', 'a@\'t"esté'];
$string = $this->engine->renderToString('Test01.latte', ['items' => $items, 'title' => 'From Test01']);
```

I'm not sure why it still report issue ` -1     Latte template Test01.latte was not analysed.` I have to dig deeper, but we already analysing your templates. 🍾 

<img width="1418" alt="image" src="https://user-images.githubusercontent.com/9377319/236352056-456406d6-42cd-4fd5-96bb-9a63e2099a85.png">
